### PR TITLE
Fix undefined variable $apiURL in callRefundAPI()

### DIFF
--- a/PaytmKit/lib/encdec_paytm.php
+++ b/PaytmKit/lib/encdec_paytm.php
@@ -250,7 +250,7 @@ function callRefundAPI($refundApiURL, $requestParamList) {
 	$responseParamList = array();
 	$JsonData =json_encode($requestParamList);
 	$postData = 'JsonData='.urlencode($JsonData);
-	$ch = curl_init($apiURL);	
+	$ch = curl_init($refundApiURL);	
 	curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
 	curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, 0);
 	curl_setopt($ch, CURLOPT_URL, $refundApiURL);


### PR DESCRIPTION
As I guess it should be functions param `$refundApiURL` instead of `$apiURL` for curl_init()